### PR TITLE
Add support for setting multiple statuses at once

### DIFF
--- a/lib/github-status/support/params.rb
+++ b/lib/github-status/support/params.rb
@@ -31,6 +31,11 @@ module GitHubStatus
       def description
         @description ||= params.fetch 'description', ''
       end
+
+      Contract None => Array
+      def statuses
+        @statuses ||= params.fetch 'statuses', []
+      end
     end
   end
 end


### PR DESCRIPTION
That is helpful for more complex check pipelines where multiple status are set to 'pending' in the beginning. That way the pending statuses are immediately visible in the pull request even if the according jobs are only run later.

While it might have been cleaner to drop support for single statuses and only support status arrays this would have been a breaking change for existing pipelines, so we chose to support both syntaxes at the same time.