### PR TITLE
Support reading commit hash from a file, rather than asking git

### DIFF
--- a/lib/github-status/in.rb
+++ b/lib/github-status/in.rb
@@ -18,7 +18,7 @@ module GitHubStatus
     Contract None => Maybe[String]
     def state
       github
-        .statuses(repo, sha)
+        .statuses(repo, canonical_sha)
         .select { |status| status.context == context }
         .map(&:state)
         .first

--- a/lib/github-status/out.rb
+++ b/lib/github-status/out.rb
@@ -17,7 +17,7 @@ module GitHubStatus
     Contract None => Or[Sawyer::Resource, ArrayOf[Sawyer::Resource]]
     def update!
       if statuses.empty?
-        github.create_status repo, sha, state, options
+        github.create_status repo, canonical_sha, state, options
       else
         statuses.map do |status|
           options = {
@@ -25,7 +25,7 @@ module GitHubStatus
             target_url: target_url,
             description: status["description"] || ""
           }
-          github.create_status repo, sha, status["state"], options
+          github.create_status repo, canonical_sha, status["state"], options
         end
       end
     rescue Octokit::Error => error
@@ -35,7 +35,7 @@ module GitHubStatus
 
     Contract None => HashOf[String, String]
     def version
-      { 'context@sha' => "#{context}@#{sha}" }
+      { 'context@sha' => "#{context}@#{canonical_sha}" }
     end
 
     Contract None => String

--- a/lib/github-status/support/git.rb
+++ b/lib/github-status/support/git.rb
@@ -17,9 +17,11 @@ module GitHubStatus
 
       Contract None => String
       def sha
-        @sha ||= (File.read "#{workdir}/#{path}").chomp
-      rescue Errno::EISDIR
-        @sha ||= git.revparse 'HEAD'
+        @sha ||= if File.file? "#{workdir}/#{path}"
+          File.read("#{workdir}/#{path}").chomp
+        else
+          git.revparse 'HEAD'
+        end
       end
     end
   end

--- a/lib/github-status/support/git.rb
+++ b/lib/github-status/support/git.rb
@@ -17,6 +17,8 @@ module GitHubStatus
 
       Contract None => String
       def sha
+        @sha ||= (File.read "#{workdir}/#{path}").chomp
+      rescue Errno::EISDIR
         @sha ||= git.revparse 'HEAD'
       end
     end

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -12,6 +12,11 @@ module GitHubStatus
       def github
         @github ||= Octokit::Client.new access_token: access_token
       end
+
+      Contract None => String
+      def canonical_sha
+        @canonical_sha ||= (sha.match(/^.{40}$/) || github.commit(repo, sha).sha).to_s
+      end
     end
   end
 end


### PR DESCRIPTION
This requires canonicalizing the status when it is not the full hash (when it is not exactly 40 characters long).

The use case here is I'm testing an artifact from a different build pipeline, where the commit ID is part of the file name (but I don't have a full checkout of the sources).