### PR TITLE
Use build name as default context and description.

### DIFF
--- a/lib/github-status/support/params.rb
+++ b/lib/github-status/support/params.rb
@@ -24,12 +24,12 @@ module GitHubStatus
 
       Contract None => String
       def context
-        @context ||= params.fetch 'context', 'concourse'
+        @context ||= params.fetch 'context', ENV["BUILD_JOB_NAME"]
       end
 
       Contract None => String
       def description
-        @description ||= params.fetch 'description', ''
+        @description ||= params.fetch 'description', "#{ENV["BUILD_JOB_NAME"]} number #{ENV["BUILD_NAME"]}"
       end
 
       Contract None => Array


### PR DESCRIPTION
If context is left blank now defaults to the environmental
variable "BUILD_JOB_NAME" which is passed as metadata by
Concourse and contains the job name.

If description is left blank now defaults to a string
specifying the build name and the build number.

This change, together with the use of anchors in the
pipeline configuration file, can significantly reduce
the amount of duplication required.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>