### PR TITLE
Add github enterprise support

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,7 @@ Add the resource to your pipeline's ~resource_types~ (requires Concourse 0.74.0+
 |--------------+----------+-------------------------------------------------------------|
 | repo         | Yes      | The GitHub repository in ~user/repo~ format                 |
 | access_token | Yes      | The access token to use with the GitHub API                 |
-| api_endpoint | No       | API endpoint of a GitHub Enterprise installation            |
+| api_endpoint | No       | Base API URL of a GitHub Enterprise installation            |
 | web_endpoint | No       | Base web URL of a GitHub Enterprise Installation            |
 |--------------+----------+-------------------------------------------------------------|
 

--- a/README.org
+++ b/README.org
@@ -25,6 +25,8 @@ Add the resource to your pipeline's ~resource_types~ (requires Concourse 0.74.0+
 |--------------+----------+-------------------------------------------------------------|
 | repo         | Yes      | The GitHub repository in ~user/repo~ format                 |
 | access_token | Yes      | The access token to use with the GitHub API                 |
+| api_endpoint | No       | API endpoint of a GitHub Enterprise installation            |
+| web_endpoint | No       | Base web URL of a GitHub Enterprise Installation            |
 |--------------+----------+-------------------------------------------------------------|
 
 * Behaviour

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -10,8 +10,8 @@ module GitHubStatus
 
       Contract None => Octokit::Client
       def github
-        Octokit.api_endpoint = api_endpoint
-        Octokit.web_endpoint = web_endpoint
+        Octokit.api_endpoint = api_endpoint if api_endpoint
+        Octokit.web_endpoint = web_endpoint if web_endpoint
         @github ||= Octokit::Client.new access_token: access_token
       end
 

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -10,6 +10,8 @@ module GitHubStatus
 
       Contract None => Octokit::Client
       def github
+        Octokit.api_endpoint = api_endpoint
+        Octokit.web_endpoint = web_endpoint
         @github ||= Octokit::Client.new access_token: access_token
       end
 

--- a/lib/github-status/support/source.rb
+++ b/lib/github-status/support/source.rb
@@ -26,6 +26,16 @@ module GitHubStatus
       def branch
         @branch ||= source.fetch('branch') { 'master' }
       end
+
+      Contract None => String
+      def api_endpoint
+        @api_endpoint ||= source.fetch('api_endpoint') { nil }
+      end
+
+      Contract None => String
+      def web_endpoint
+        @web_endpoint ||= source.fetch('web_endpoint') { nil }
+      end
     end
   end
 end


### PR DESCRIPTION
adds source config for github enterprise endpoints and conditionally assigns them before client creation